### PR TITLE
Flush autosave before swipe clear

### DIFF
--- a/Zettel/Utilities/ChangelogData.swift
+++ b/Zettel/Utilities/ChangelogData.swift
@@ -15,6 +15,21 @@ enum ChangelogData {
     /// All changelog entries - add new versions at the TOP
     static let entries: [(version: String, title: String, content: String)] = [
         (
+            version: "2.3",
+            title: "v2.3 - What's New",
+            content: """
+            Welcome to Zettel v2.3!
+
+            ## 🛠 Improvements
+
+            - **Swipe Reliability**: Swiping to create a new note now flushes any pending auto-save first, so quick swipes won't lose last-second edits.
+            
+            ---
+
+            Thank you for using Zettel! 💛
+            """
+        ),
+        (
             version: "2.2",
             title: "v2.2 - What's New",
             content: """


### PR DESCRIPTION
Fixes a race where a quick swipe could clear the note before the debounced auto-save fired. Swiping to create a new note now flushes any pending auto-save first, preventing last-second edits from being lost. Adds a v2.3 changelog entry for the improvement.