### PR TITLE
feat(mac): lower macOS deployment target to 15.0 (Sequoia)

### DIFF
--- a/Packages/ZettelKit/Package.swift
+++ b/Packages/ZettelKit/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "ZettelKit",
     platforms: [
-        .macOS(.v26),
+        .macOS(.v15),
         .iOS(.v26)
     ],
     products: [

--- a/Zettel.xcodeproj/project.pbxproj
+++ b/Zettel.xcodeproj/project.pbxproj
@@ -254,7 +254,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 26.0;
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
 				MARKETING_VERSION = 1.2;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "";
@@ -496,7 +496,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 26.0;
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
 				MARKETING_VERSION = 1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "";
 				PRODUCT_NAME = Zettel;

--- a/ZettelMac/Info.plist
+++ b/ZettelMac/Info.plist
@@ -24,7 +24,7 @@
 		</dict>
 	</array>
 	<key>LSMinimumSystemVersion</key>
-	<string>26.0</string>
+	<string>15.0</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 </dict>

--- a/ZettelMac/Preferences/MacDockIconPreference.swift
+++ b/ZettelMac/Preferences/MacDockIconPreference.swift
@@ -36,7 +36,7 @@ enum MacDockIconPreference {
         let activationPolicy: NSApplication.ActivationPolicy = shouldHide ? .accessory : .regular
         let didSet = NSApplication.shared.setActivationPolicy(activationPolicy)
         if !didSet {
-            let currentIsHidden = NSApplication.shared.activationPolicy == .accessory
+            let currentIsHidden = NSApplication.shared.activationPolicy() == .accessory
             UserDefaults.standard.set(currentIsHidden, forKey: storageKey)
         }
     }

--- a/ZettelMac/Views/TagAutocompletePanel.swift
+++ b/ZettelMac/Views/TagAutocompletePanel.swift
@@ -99,7 +99,7 @@ struct TagSuggestionsView: View {
             }
         }
         .padding(.vertical, 4)
-        .glassEffect(in: .rect(cornerRadius: 10))
+        .modifier(GlassEffectFallback(cornerRadius: 10))
         // No SwiftUI shadow — NSHostingView clips it to a hard rect.
         // p.hasShadow = true on the NSPanel gives the correct shaped shadow.
     }
@@ -154,6 +154,21 @@ private struct TagSuggestionRow: View {
             onHoverChanged?(hovering)
         }
         .animation(.easeInOut(duration: 0.1), value: isHovered)
+    }
+}
+
+// MARK: - Glass Effect Fallback
+
+/// Applies `.glassEffect` on macOS 26+, falls back to `.background(.ultraThinMaterial)` on earlier versions.
+private struct GlassEffectFallback: ViewModifier {
+    let cornerRadius: CGFloat
+
+    func body(content: Content) -> some View {
+        if #available(macOS 26, *) {
+            content.glassEffect(in: .rect(cornerRadius: cornerRadius))
+        } else {
+            content.background(.ultraThinMaterial, in: .rect(cornerRadius: cornerRadius))
+        }
     }
 }
 

--- a/ZettelMac/Window/ZettelWindowManager.swift
+++ b/ZettelMac/Window/ZettelWindowManager.swift
@@ -215,9 +215,11 @@ final class ZettelWindowManager: NSObject, ObservableObject {
         panel.titlebarAppearsTransparent = true
         panel.titleVisibility = .hidden
 
-        // Transparent background for Liquid Glass
-        panel.isOpaque = false
-        panel.backgroundColor = .clear
+        // Transparent background for Liquid Glass (macOS 26+)
+        if #available(macOS 26, *) {
+            panel.isOpaque = false
+            panel.backgroundColor = .clear
+        }
 
         // Set min size
         panel.minSize = NSSize(width: 420, height: 380)


### PR DESCRIPTION
## Summary
- Lower macOS deployment target from 26.0 to 15.0 (Sequoia) to support wider audience
- Add `#available(macOS 26, *)` guards for Liquid Glass APIs with `ultraThinMaterial` fallbacks
- Fix `activationPolicy()` call syntax for macOS 15 compatibility
- iOS target remains at iOS 26

## Changes
- `Package.swift`: macOS platform `.v26` → `.v15`
- `project.pbxproj`: `MACOSX_DEPLOYMENT_TARGET` 26.0 → 15.0
- `Info.plist`: `LSMinimumSystemVersion` 26.0 → 15.0
- `TagAutocompletePanel`: `glassEffect` wrapped in `#available` with `ultraThinMaterial` fallback
- `ZettelWindowManager`: Liquid Glass transparent background wrapped in `#available`
- `MacDockIconPreference`: `activationPolicy` → `activationPolicy()` (method call on macOS 15)

## Test plan
- [ ] Build ZettelMac scheme — no availability errors
- [ ] Run on macOS 15 — app launches, windows display correctly with opaque background
- [ ] Run on macOS 26 — Liquid Glass effects still work
- [ ] Tag autocomplete panel renders correctly on both OS versions