### PR TITLE
macOS: fix sidebar persistence, Dock behavior, and Settings window quit

### DIFF
--- a/Zettel.xcodeproj/project.pbxproj
+++ b/Zettel.xcodeproj/project.pbxproj
@@ -238,7 +238,7 @@
 				CODE_SIGN_ENTITLEMENTS = ZettelMac/ZettelMac.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 22;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_APP_SANDBOX = YES;
@@ -255,7 +255,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.3;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "";
 				PRODUCT_NAME = Zettel;
@@ -482,7 +482,7 @@
 				CODE_SIGN_ENTITLEMENTS = ZettelMac/ZettelMac.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 22;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = "";
 				ENABLE_APP_SANDBOX = YES;
@@ -497,7 +497,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "";
 				PRODUCT_NAME = Zettel;
 				SDKROOT = macosx;

--- a/ZettelMac/AppDelegate.swift
+++ b/ZettelMac/AppDelegate.swift
@@ -80,7 +80,11 @@ final class ZettelAppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
-        return MacDockIconPreference.isHidden()
+        // Only quit when the Dock icon is hidden AND no note windows remain.
+        // The Settings window doesn't count — without this check, closing
+        // Settings as the last window would quit the app unexpectedly.
+        guard MacDockIconPreference.isHidden() else { return false }
+        return ZettelWindowManager.shared.hasNoWindows
     }
 
     func applicationWillTerminate(_ notification: Notification) {

--- a/ZettelMac/AppDelegate.swift
+++ b/ZettelMac/AppDelegate.swift
@@ -19,6 +19,10 @@ final class ZettelAppDelegate: NSObject, NSApplicationDelegate {
         if isFirstLaunch() {
             let welcomeNote = createWelcomeNote()
             ZettelWindowManager.shared.createWindow(note: welcomeNote)
+        } else if let changelogNote = MacChangelogManager.shared.pendingChangelogNote() {
+            // Show changelog note for this update
+            ZettelWindowManager.shared.createWindow(note: changelogNote)
+            MacChangelogManager.shared.markSeen()
         } else {
             // Try to restore the last opened note
             let restoredNote = restoreLastOpenedNote()

--- a/ZettelMac/AppDelegate.swift
+++ b/ZettelMac/AppDelegate.swift
@@ -68,15 +68,15 @@ final class ZettelAppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
-        if !flag {
-            // No visible windows — restore last note or create a new one
+        if ZettelWindowManager.shared.hasNoWindows {
+            // No note windows — create one
             let restoredNote = restoreLastOpenedNote()
             ZettelWindowManager.shared.createWindow(note: restoredNote)
         } else {
-            // Focus all existing windows
-            ZettelWindowManager.shared.focusAllWindows()
+            // Focus the last active note window
+            ZettelWindowManager.shared.focusLastWindow()
         }
-        return true
+        return false
     }
 
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {

--- a/ZettelMac/Preferences/MacDockIconPreference.swift
+++ b/ZettelMac/Preferences/MacDockIconPreference.swift
@@ -36,7 +36,7 @@ enum MacDockIconPreference {
         let activationPolicy: NSApplication.ActivationPolicy = shouldHide ? .accessory : .regular
         let didSet = NSApplication.shared.setActivationPolicy(activationPolicy)
         if !didSet {
-            let currentIsHidden = NSApplication.shared.activationPolicy == .accessory
+            let currentIsHidden = NSApplication.shared.activationPolicy() == .accessory
             UserDefaults.standard.set(currentIsHidden, forKey: storageKey)
         }
     }

--- a/ZettelMac/Stores/MacChangelogData.swift
+++ b/ZettelMac/Stores/MacChangelogData.swift
@@ -1,0 +1,39 @@
+//
+//  MacChangelogData.swift
+//  ZettelMac
+//
+//  Static changelog data for the macOS app.
+//  Add new changelog entries at the TOP of the array (newest first).
+//
+
+import Foundation
+
+enum MacChangelogData {
+
+    /// All changelog entries - add new versions at the TOP
+    static let entries: [(version: String, title: String, content: String)] = [
+        (
+            version: "1.3",
+            title: "v1.3 - Reliability Update",
+            content: """
+            ## Bug Fix
+
+            Fixed a bug where the **sidebar appeared empty** after a system restart or app update, requiring you to re-select your notes folder in Settings.
+
+            ## Action Required
+
+            Because of how this fix works, you'll need to **re-select your notes folder one last time**:
+
+            1. Open **Settings** (Cmd + ,)
+            2. Click **Change...** next to Storage Location
+            3. Select your notes folder
+
+            After this, your folder choice will persist correctly through future restarts and updates.
+
+            ---
+
+            Thank you for using Zettel!
+            """
+        ),
+    ]
+}

--- a/ZettelMac/Stores/MacChangelogManager.swift
+++ b/ZettelMac/Stores/MacChangelogManager.swift
@@ -1,0 +1,61 @@
+//
+//  MacChangelogManager.swift
+//  ZettelMac
+//
+//  Manages changelog display for macOS app version updates.
+//  Mirrors the iOS ChangelogManager pattern.
+//
+
+import Foundation
+import ZettelKit
+
+@MainActor
+final class MacChangelogManager {
+    static let shared = MacChangelogManager()
+
+    private let lastSeenVersionKey = "macLastSeenAppVersion"
+    private let hasLaunchedBeforeKey = "hasLaunchedBefore"
+
+    private init() {}
+
+    /// Returns a changelog `Note` if the user is upgrading to a version that has one.
+    /// Returns `nil` for first-time users or if the user has already seen this version.
+    func pendingChangelogNote() -> Note? {
+        guard let currentVersion = bundleVersion() else { return nil }
+
+        // First-time users see the welcome note, not a changelog
+        let hasLaunchedBefore = UserDefaults.standard.bool(forKey: hasLaunchedBeforeKey)
+        guard hasLaunchedBefore else { return nil }
+
+        let lastSeen = UserDefaults.standard.string(forKey: lastSeenVersionKey)
+
+        // Already seen this version
+        if lastSeen == currentVersion { return nil }
+
+        // Find a matching changelog entry
+        guard let entry = MacChangelogData.entries.first(where: { $0.version == currentVersion }) else {
+            // No changelog for this version — record it as seen
+            markSeen()
+            return nil
+        }
+
+        return Note(title: entry.title, content: entry.content)
+    }
+
+    /// Mark the current version as seen so the changelog won't show again.
+    func markSeen() {
+        if let version = bundleVersion() {
+            UserDefaults.standard.set(version, forKey: lastSeenVersionKey)
+        }
+    }
+
+    private func bundleVersion() -> String? {
+        // Use major.minor only (strip patch) to match ChangelogData keys like "1.3"
+        guard let full = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String else {
+            return nil
+        }
+        let parts = full.split(separator: ".")
+        guard parts.count >= 2 else { return full }
+        return "\(parts[0]).\(parts[1])"
+    }
+}

--- a/ZettelMac/Stores/MacNoteStore.swift
+++ b/ZettelMac/Stores/MacNoteStore.swift
@@ -115,15 +115,19 @@ public final class MacNoteStore: NSObject, NSFilePresenter {
         let directory = storageDirectory
         let notes = await Task.detached { () -> [Note] in
             let fm = FileManager.default
-            guard let files = try? fm.contentsOfDirectory(
-                at: directory,
-                includingPropertiesForKeys: [
-                    .contentModificationDateKey,
-                    .creationDateKey,
-                    .ubiquitousItemDownloadingStatusKey
-                ],
-                options: [.skipsHiddenFiles]
-            ) else {
+            let files: [URL]
+            do {
+                files = try fm.contentsOfDirectory(
+                    at: directory,
+                    includingPropertiesForKeys: [
+                        .contentModificationDateKey,
+                        .creationDateKey,
+                        .ubiquitousItemDownloadingStatusKey
+                    ],
+                    options: [.skipsHiddenFiles]
+                )
+            } catch {
+                print("[MacNoteStore] Error listing directory \(directory.path): \(error)")
                 return []
             }
 
@@ -501,7 +505,7 @@ public final class MacNoteStore: NSObject, NSFilePresenter {
     private func saveStorageDirectoryBookmark(_ url: URL) {
         do {
             let bookmark = try url.bookmarkData(
-                options: [],
+                options: .withSecurityScope,
                 includingResourceValuesForKeys: nil,
                 relativeTo: nil
             )
@@ -520,7 +524,7 @@ public final class MacNoteStore: NSObject, NSFilePresenter {
             var isStale = false
             let url = try URL(
                 resolvingBookmarkData: bookmark,
-                options: [],
+                options: .withSecurityScope,
                 relativeTo: nil,
                 bookmarkDataIsStale: &isStale
             )
@@ -529,7 +533,9 @@ public final class MacNoteStore: NSObject, NSFilePresenter {
                 saveStorageDirectoryBookmark(url)
             }
 
-            _ = url.startAccessingSecurityScopedResource()
+            if !url.startAccessingSecurityScopedResource() {
+                print("[MacNoteStore] Warning: failed to start security-scoped access for \(url.path)")
+            }
             return url
         } catch {
             print("[MacNoteStore] Error restoring bookmark: \(error)")

--- a/ZettelMac/Window/ZettelWindowManager.swift
+++ b/ZettelMac/Window/ZettelWindowManager.swift
@@ -114,6 +114,21 @@ final class ZettelWindowManager: NSObject, ObservableObject {
         window.level = pinned ? .floating : .normal
     }
 
+    /// Focus just the last active note window (used by Dock click).
+    func focusLastWindow() {
+        NSApp.activate(ignoringOtherApps: true)
+
+        if let lastId = lastFocusedWindowId, let window = nsWindows[lastId] {
+            if window.isMiniaturized { window.deminiaturize(nil) }
+            window.makeKeyAndOrderFront(nil)
+        } else if let (id, window) = nsWindows.first {
+            if window.isMiniaturized { window.deminiaturize(nil) }
+            window.makeKeyAndOrderFront(nil)
+            lastFocusedWindowId = id
+        }
+    }
+
+    /// Bring all note windows to the front.
     func focusAllWindows() {
         guard !nsWindows.isEmpty else { return }
         NSApp.activate(ignoringOtherApps: true)

--- a/ZettelMac/Window/ZettelWindowManager.swift
+++ b/ZettelMac/Window/ZettelWindowManager.swift
@@ -25,6 +25,9 @@ final class ZettelWindowManager: NSObject, ObservableObject {
     /// Delegates kept alive keyed by window ID
     private var windowDelegates: [UUID: ZettelWindowDelegate] = [:]
 
+    /// Whether all note windows have been closed.
+    var hasNoWindows: Bool { windowStates.isEmpty }
+
     /// Last focused window (for keyboard shortcut routing)
     private(set) var lastFocusedWindowId: UUID?
 


### PR DESCRIPTION
## Summary

A batch of macOS bug fixes and a changelog system for update notes.

### Sidebar empty after restart / app update
- Security-scoped bookmarks were created with `options: []` instead of `.withSecurityScope`, so sandbox access wasn't persisted in the bookmark data — sidebar silently loaded empty after OS updates or app re-signs cleared the cached grants
- Added error logging for `contentsOfDirectory` failures (was swallowed by `try?`)
- Added logging when `startAccessingSecurityScopedResource()` fails

### Dock icon click behavior
- Clicking the Dock icon always created a new window instead of focusing the existing one — `hasVisibleWindows` is unreliable for NSPanel windows with accessory activation policy
- Now uses our own window tracking (`hasNoWindows`) and returns `false` from `applicationShouldHandleReopen` to prevent macOS default behavior competing with ours
- First window created from Dock click (when all closed) was broken with Stage Manager — caused by `return true` letting macOS also run its default reopen on top of ours

### Settings window quit
- Closing the Settings window as the last window quit the entire app because `applicationShouldTerminateAfterLastWindowClosed` only checked the Dock icon preference, not whether note windows still exist

### Other
- Fixed `activationPolicy` missing parentheses in `MacDockIconPreference` (method, not property)
- Added macOS changelog system (`MacChangelogData` + `MacChangelogManager`) mirroring the iOS pattern — shows an update note on first launch after upgrade

## Note for existing users

Users will need to re-select their storage folder **once** after updating to v1.3, since the old bookmark was created without `.withSecurityScope`. The changelog note explains this on first launch.

## Test plan

- [ ] Select a custom notes folder, quit, relaunch — sidebar should retain notes
- [ ] Click Dock icon with a window open — should focus it, not create a new one
- [ ] Close all windows, click Dock icon — should create one window that works with Stage Manager
- [ ] Open Settings, close it — app should not quit
- [ ] Open multiple windows, click Dock icon — should focus the last-used window

🤖 Generated with [Claude Code](https://claude.com/claude-code)